### PR TITLE
add pod range for 1000 ips

### DIFF
--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -16,7 +16,7 @@ version:
 
 stages:
   build:
-    image: golang:1.15.2-alpine3.12
+    image: golang:1.17-alpine
     env:
       CGO_ENABLED: 0
       GOGC: off
@@ -82,7 +82,7 @@ stages:
       status == 'succeeded' && '${ESTAFETTE_GIT_BRANCH}' == '${ESTAFETTE_BUILD_VERSION}'
 
   push-dev-to-tap:
-    image: golang:1.15.2-alpine3.12
+    image: golang:1.17-alpine
     commands:
     - apk add git
     - cd homebrew-dev
@@ -96,7 +96,7 @@ stages:
       status == 'succeeded' && '${ESTAFETTE_GIT_BRANCH}' != '${ESTAFETTE_BUILD_VERSION}'
 
   push-stable-to-tap:
-    image: golang:1.15.2-alpine3.12
+    image: golang:1.17-alpine
     commands:
     - apk add git
     - cd homebrew-stable

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 estafette-gcp-network-planner
+.idea

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/.idea/estafette-gcp-network-planner.iml
+++ b/.idea/estafette-gcp-network-planner.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="Go" enabled="true" />
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/estafette-gcp-network-planner.iml" filepath="$PROJECT_DIR$/.idea/estafette-gcp-network-planner.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="ALL" />
+  </component>
+  <component name="ChangeListManager">
+    <list default="true" id="14244f64-e875-47b7-bb1b-517ef2283e7b" name="Changes" comment="">
+      <change beforePath="$PROJECT_DIR$/api/network/v1/config.json" beforeDir="false" afterPath="$PROJECT_DIR$/api/network/v1/config.json" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/services/planner/test-config.json" beforeDir="false" afterPath="$PROJECT_DIR$/services/planner/test-config.json" afterDir="false" />
+    </list>
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="GOROOT" url="file:///usr/local/opt/go/libexec" />
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="GoLibraries">
+    <option name="indexEntireGoPath" value="false" />
+  </component>
+  <component name="ProjectId" id="24mgmnKDsXURyK47S5Em55LdXPx" />
+  <component name="ProjectLevelVcsManager" settingsEditedManually="true" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent">
+    <property name="RunOnceActivity.OpenProjectViewOnStart" value="true" />
+    <property name="RunOnceActivity.ShowReadmeOnStart" value="true" />
+    <property name="WebServerToolWindowFactoryState" value="false" />
+    <property name="go.formatter.settings.were.checked" value="true" />
+    <property name="go.import.settings.migrated" value="true" />
+    <property name="go.modules.go.list.on.any.changes.was.set" value="true" />
+    <property name="go.sdk.automatically.set" value="true" />
+    <property name="last_opened_file_path" value="$PROJECT_DIR$" />
+    <property name="settings.editor.selected.configurable" value="preferences.lookFeel" />
+  </component>
+  <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="application-level" UseSingleDictionary="true" transferred="true" />
+  <component name="TypeScriptGeneratedFilesManager">
+    <option name="version" value="3" />
+  </component>
+  <component name="Vcs.Log.Tabs.Properties">
+    <option name="TAB_STATES">
+      <map>
+        <entry key="MAIN">
+          <value>
+            <State />
+          </value>
+        </entry>
+      </map>
+    </option>
+  </component>
+  <component name="VgoProject">
+    <integration-enabled>true</integration-enabled>
+  </component>
+</project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,8 +5,12 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="14244f64-e875-47b7-bb1b-517ef2283e7b" name="Changes" comment="">
-      <change beforePath="$PROJECT_DIR$/api/network/v1/config.json" beforeDir="false" afterPath="$PROJECT_DIR$/api/network/v1/config.json" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/services/planner/test-config.json" beforeDir="false" afterPath="$PROJECT_DIR$/services/planner/test-config.json" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/.idea/.gitignore" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/.idea/estafette-gcp-network-planner.iml" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/.idea/modules.xml" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/.idea/vcs.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.gitignore" beforeDir="false" afterPath="$PROJECT_DIR$/.gitignore" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -37,6 +41,25 @@
     <property name="last_opened_file_path" value="$PROJECT_DIR$" />
     <property name="settings.editor.selected.configurable" value="preferences.lookFeel" />
   </component>
+  <component name="RunManager">
+    <configuration default="true" type="GoApplicationRunConfiguration" factoryName="Go Application">
+      <module name="estafette-gcp-network-planner" />
+      <working_directory value="$PROJECT_DIR$" />
+      <kind value="FILE" />
+      <directory value="$PROJECT_DIR$" />
+      <filePath value="$PROJECT_DIR$" />
+      <method v="2" />
+    </configuration>
+    <configuration default="true" type="GoTestRunConfiguration" factoryName="Go Test">
+      <module name="estafette-gcp-network-planner" />
+      <working_directory value="$PROJECT_DIR$" />
+      <kind value="DIRECTORY" />
+      <directory value="$PROJECT_DIR$" />
+      <filePath value="$PROJECT_DIR$" />
+      <framework value="gotest" />
+      <method v="2" />
+    </configuration>
+  </component>
   <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="application-level" UseSingleDictionary="true" transferred="true" />
   <component name="TypeScriptGeneratedFilesManager">
     <option name="version" value="3" />
@@ -51,6 +74,7 @@
         </entry>
       </map>
     </option>
+    <option name="oldMeFiltersMigrated" value="true" />
   </component>
   <component name="VgoProject">
     <integration-enabled>true</integration-enabled>

--- a/api/network/v1/config.json
+++ b/api/network/v1/config.json
@@ -6,12 +6,12 @@
       "comment": "Every subnet has four reserved IP addresses in its primary IP range",
       "network": "172.28.0.0/14",
       "subnet_mask": 21
-    }, {
+    },{
       "type": "pod",
       "ip_cidr_range_type": "secondary",
-      "network": "10.0.0.0/9",
-      "comment": "Large enough to fit (total number of nodes X 256) IP addresses",
-      "subnet_mask": 16
+      "network": "10.128.0.0/9",
+      "comment": "Large enough to fit (total number of nodes X 1000) IP addresses",
+      "subnet_mask": 14
     }, {
       "type": "service",
       "ip_cidr_range_type": "secondary",

--- a/api/network/v1/config.json
+++ b/api/network/v1/config.json
@@ -13,12 +13,6 @@
       "comment": "Large enough to fit (total number of nodes X 256) IP addresses",
       "subnet_mask": 16
     }, {
-      "type": "pod",
-      "ip_cidr_range_type": "secondary",
-      "network": "10.128.0.0/9",
-      "comment": "Large enough to fit (total number of nodes X 1000) IP addresses",
-      "subnet_mask": 14
-    }, {
       "type": "service",
       "ip_cidr_range_type": "secondary",
       "network": "172.24.0.0/14",

--- a/api/network/v1/config.json
+++ b/api/network/v1/config.json
@@ -13,6 +13,12 @@
       "comment": "Large enough to fit (total number of nodes X 256) IP addresses",
       "subnet_mask": 16
     }, {
+      "type": "pod",
+      "ip_cidr_range_type": "secondary",
+      "network": "10.128.0.0/9",
+      "comment": "Large enough to fit (total number of nodes X 1000) IP addresses",
+      "subnet_mask": 14
+    }, {
       "type": "service",
       "ip_cidr_range_type": "secondary",
       "network": "172.24.0.0/14",

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,3 @@
-cloud.google.com/go v0.26.0 h1:e0WKqKTd5BnrG8aKH3J3h+QvEIQtSUcf2n5UZ5ZgLtQ=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
@@ -101,7 +100,6 @@ github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
 github.com/golang/protobuf v1.3.4/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
-github.com/golang/protobuf v1.3.5 h1:F768QJ1E9tib+q5Sc8MkdJi1RxLTbRcTf8LJV56aRls=
 github.com/golang/protobuf v1.3.5/go.mod h1:6O5/vntMXwX2lRkT1hjjk0nAC1IDOTvTlVgjlRvqsdk=
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
 github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:xKAWHe0F5eneWXFV3EuXVDTCmh+JuBKY0li0aMyXATA=
@@ -305,7 +303,6 @@ golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200222125558-5a598a2470a0/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20200226121028-0de0cce0169b h1:0mm1VjtFUOIlE1SbDlwjYaDxZVDP2S5ou6y0gSgXHu8=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
@@ -317,7 +314,6 @@ golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200822124328-c89045814202 h1:VvcQYSHwXgi7W+TpUR6A9g6Up98WAHf3f/ulnJ62IyA=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
-golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be h1:vEDujvNQGv4jgYKudGeI/+DAX4Jffq6hpD55MmoEvKs=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -354,7 +350,6 @@ golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200331124033-c3d80250170d h1:nc5K6ox/4lTFbMVSL9WRR81ixkcwXThoiF6yf+R9scA=
 golang.org/x/sys v0.0.0-20200331124033-c3d80250170d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200501052902-10377860bb8e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200511232937-7e40ca221e25/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/services/planner/test-config.json
+++ b/services/planner/test-config.json
@@ -7,12 +7,6 @@
       "comment": "Large enough to fit (total number of nodes X 256) IP addresses",
       "subnet_mask": 16
     }, {
-      "type": "pod",
-      "ip_cidr_range_type": "secondary",
-      "network": "10.128.0.0/9",
-      "comment": "Large enough to fit (total number of nodes X 1000) IP addresses",
-      "subnet_mask": 14
-    },{
       "type": "node",
       "ip_cidr_range_type": "primary",
       "comment": "Every subnet has four reserved IP addresses in its primary IP range",

--- a/services/planner/test-config.json
+++ b/services/planner/test-config.json
@@ -3,10 +3,10 @@
     {
       "type": "pod",
       "ip_cidr_range_type": "secondary",
-      "network": "10.0.0.0/9",
-      "comment": "Large enough to fit (total number of nodes X 256) IP addresses",
-      "subnet_mask": 16
-    }, {
+      "network": "10.128.0.0/9",
+      "comment": "Large enough to fit (total number of nodes X 1000) IP addresses",
+      "subnet_mask": 14
+    },{
       "type": "node",
       "ip_cidr_range_type": "primary",
       "comment": "Every subnet has four reserved IP addresses in its primary IP range",

--- a/services/planner/test-config.json
+++ b/services/planner/test-config.json
@@ -7,6 +7,12 @@
       "comment": "Large enough to fit (total number of nodes X 256) IP addresses",
       "subnet_mask": 16
     }, {
+      "type": "pod",
+      "ip_cidr_range_type": "secondary",
+      "network": "10.128.0.0/9",
+      "comment": "Large enough to fit (total number of nodes X 1000) IP addresses",
+      "subnet_mask": 14
+    },{
       "type": "node",
       "ip_cidr_range_type": "primary",
       "comment": "Every subnet has four reserved IP addresses in its primary IP range",


### PR DESCRIPTION
The network planner currently only supports /16 ip addresses, thus restricting us from having more than 500 nodes if needed. For clusters like rules which needs > 500 nodes this won’t work. So this PR will allow us to accomodate the above feature